### PR TITLE
Issue-14: Normalize Validation#orElse and orElseGet

### DIFF
--- a/data/Either.js
+++ b/data/Either.js
@@ -416,13 +416,33 @@ class Either {
    */
 
   /**
+   * Applies the provided function to the value contain for a {@link Left}. Any return value from the function is
+   * ignored. If the instance is a {@link Right}, the function is ignored and the instance is returned.
+   * @abstract
+   * @function ifLeft
+   * @memberof Either
+   * @instance
+   * @param {Consumer} method - The function to invoke with the value.
+   * @return {Either} Current instance.
+   * @example <caption>Right#ifLeft</caption>
+   *
+   * Right.from(value).ifLeft(doSomething); // void
+   * // => Right(value)
+   *
+   * @example <caption>Left#ifLeft</caption>
+   *
+   * Left.from(error).ifLeft(doSomething); // doSomething(error)
+   * // => Left(error)
+   */
+
+  /**
    * Applies the provided function to the value contain for a {@link Right}. Any return value from the function is
    * ignored. If the instance is a {@link Left}, the function is ignored and the instance is returned.
    * @abstract
    * @function ifRight
    * @memberof Either
    * @instance
-   * @param {Consumer} method -The function to invoke with the value;
+   * @param {Consumer} method - The function to invoke with the value.
    * @return {Either} Current instance.
    * @example <caption>Right#ifRight</caption>
    *
@@ -501,7 +521,7 @@ class Either {
    * @function orElse
    * @memberof Either
    * @instance
-   * @param {Consumer} method - The function to invoke with the value;
+   * @param {Consumer} method - The function to invoke with the value.
    * @return {*}
    * @example <caption>Right#orElse</caption>
    *
@@ -540,7 +560,7 @@ class Either {
    * @function orElseThrow
    * @memberof Either
    * @instance
-   * @param {Function} method -The function to invoke with the value.
+   * @param {Function} method - The function to invoke with the value.
    * @return {*}
    * @throws {Error} returned by the provided function.
    * @example <caption>Right#orElseThrow</caption>

--- a/data/Maybe.js
+++ b/data/Maybe.js
@@ -435,7 +435,7 @@ class Maybe {
    * @function ifJust
    * @memberof Maybe
    * @instance
-   * @param {Consumer} method -The function to invoke with the value;
+   * @param {Consumer} method - The function to invoke with the value.
    * @return {Maybe} Current instance.
    * @example <caption>Just#ifJust</caption>
    *
@@ -445,6 +445,27 @@ class Maybe {
    * @example <caption>Nothing#ifJust</caption>
    *
    * Nothing.from().ifJust(doSomething); // void
+   * // => Nothing()
+   */
+
+  //
+  /**
+   * Applies the provided function to the value contain for a {@link Nothing}. Any return value from the function is
+   * ignored. If the instance is a {@link Just}, the function is ignored and the instance is returned.
+   * @abstract
+   * @function ifNothing
+   * @memberof Maybe
+   * @instance
+   * @param {Callable} method - The function to invoke.
+   * @return {Maybe} Current instance.
+   * @example <caption>Just#ifNothing</caption>
+   *
+   * Just.from(value).ifNothing(doSomething); // void
+   * // => Just(value)
+   *
+   * @example <caption>Nothing#ifNothing</caption>
+   *
+   * Nothing.from().ifNothing(doSomething); // doSomething()
    * // => Nothing()
    */
 
@@ -515,7 +536,7 @@ class Maybe {
    * @function orElse
    * @memberof Maybe
    * @instance
-   * @param {Consumer} method - The function to invoke with the value;
+   * @param {Consumer} method - The function to invoke with the value.
    * @return {*}
    * @example <caption>Just#orElse</caption>
    *
@@ -543,7 +564,7 @@ class Maybe {
    *
    * @example <caption>Nothing#orElseGet</caption>
    *
-   * Nothing.from().orElse(getOtherValue);
+   * Nothing.from().orElseGet(getOtherValue);
    * // => otherValue
    */
 
@@ -554,7 +575,7 @@ class Maybe {
    * @function orElseThrow
    * @memberof Maybe
    * @instance
-   * @param {Supplier} method -The function to invoke with the value.
+   * @param {Supplier} method - The function to invoke with the value.
    * @return {*}
    * @throws {Error} returned by the provided function.
    * @example <caption>Just#orElseThrow</caption>

--- a/data/Validation.js
+++ b/data/Validation.js
@@ -505,13 +505,33 @@ class Validation {
    */
 
   /**
+   * Applies the provided function to the value contain for a {@link Failure}. Any return value from the function is
+   * ignored. If the instance is a {@link Success}, the function is ignored and the instance is returned.
+   * @abstract
+   * @function ifFailure
+   * @memberof Validation
+   * @instance
+   * @param {Consumer} method - The function to invoke with the value.
+   * @return {Validation} Current instance.
+   * @example <caption>Success#ifFailure</caption>
+   *
+   * Success.from(value).ifFailure(doSomething); // void
+   * // => Success(value)
+   *
+   * @example <caption>Failure#ifFailure</caption>
+   *
+   * Failure.from(error).ifFailure(doSomething); // doSomething([error])
+   * // => Failure([error])
+   */
+
+  /**
    * Applies the provided function to the value contain for a {@link Success}. Any return value from the function is
    * ignored. If the instance is a {@link Failure}, the function is ignored and the instance is returned.
    * @abstract
    * @function ifSuccess
    * @memberof Validation
    * @instance
-   * @param {Consumer} method -The function to invoke with the value;
+   * @param {Consumer} method - The function to invoke with the value.
    * @return {Validation} Current instance.
    * @example <caption>Success#ifSuccess</caption>
    *
@@ -596,13 +616,32 @@ class Validation {
    * @return {Validation} Current instance.
    * @example <caption>Success#orElse</caption>
    *
-   * Success.from(value).orElse(doSomething); // void
-   * // => Success(value)
+   * Success.from(value).orElse(otherValue);
+   * // => value
    *
    * @example <caption>Failure#orElse</caption>
    *
-   * Failure.from(error).orElse(doSomething); // doSomething([error])
-   * // => Failure([error])
+   * Failure.from(error).orElse(otherValue);
+   * // => otherValue
+   */
+
+  /**
+   * Return the value if the instance is a {@link Success} otherwise returns the value from the function provided.
+   * @abstract
+   * @function orElseGet
+   * @memberof Validation
+   * @instance
+   * @param {Supplier} method - The function supplying the optional value.
+   * @return {*}
+   * @example <caption>Success#orElseGet</caption>
+   *
+   * Success.from(value).orElseGet(getOtherValue);
+   * // => value
+   *
+   * @example <caption>Failure#orElseGet</caption>
+   *
+   * Failure.from().orElseGet(getOtherValue);
+   * // => otherValue
    */
 
   /**
@@ -996,6 +1035,12 @@ class Failure extends Validation {
     return this;
   }
 
+  ifFailure(method) {
+    method(this.value);
+
+    return this;
+  }
+
   ifSuccess() {
     return this;
   }
@@ -1004,10 +1049,12 @@ class Failure extends Validation {
     return this;
   }
 
-  orElse(method) {
-    method(this.value);
+  orElse(value) {
+    return value;
+  }
 
-    return this;
+  orElseGet(method) {
+    return method();
   }
 
   orElseThrow(method) {
@@ -1094,6 +1141,10 @@ class Success extends Validation {
     return Validation.from(method(this));
   }
 
+  ifFailure() {
+    return this;
+  }
+
   ifSuccess(method) {
     method(this.value);
 
@@ -1105,11 +1156,15 @@ class Success extends Validation {
   }
 
   orElse() {
-    return this;
+    return this.value;
+  }
+
+  orElseGet() {
+    return this.value;
   }
 
   orElseThrow() {
-    void 0;
+    return this.value;
   }
 
   toEither(either) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 "use strict";
 
 /**
+ * @typedef Callable
+ * @type Function
+ * @description A <code>function</code> with no arguments or return value.
+ */
+
+/**
  * @typedef Chain
  * @type Function
  * @description A unary <code>function</code> that takes a <code>value</code> and returns a <code>value</code>

--- a/test/EitherSpec.js
+++ b/test/EitherSpec.js
@@ -352,31 +352,34 @@ describe("Either", () => {
 
     describe("#orElse", () => {
       const testLeft = new Left(testMessage);
+      const expectedResult = testValue;
       let actualResult = null;
 
       before(() => actualResult = testLeft.orElse(testValue));
 
-      it("should return the value passed to the orElse method", () => expect(actualResult).to.equal(testValue));
+      it("should return the value passed", () => expect(actualResult).to.equal(expectedResult));
     });
 
     describe("#orElseGet", () => {
-      it("should return the value supplied by the function passed", () => {
-        const testValueSupplier = () => testValue;
-        const expectedResult = testValue;
+      const testLeft = new Left(testMessage);
+      const testValueSupplier = () => testValue;
+      const expectedResult = testValue;
+      let actualResult = null;
 
-        expect(Left.from(testMessage).orElseGet(testValueSupplier)).to.equal(expectedResult);
-      });
+      before(() => actualResult = testLeft.orElseGet(testValueSupplier));
+
+      it("should return the value supplied by the function passed", () =>
+        expect(actualResult).to.equal(expectedResult)
+      );
     });
 
     describe("#orElseThrow", () => {
       const testLeft = new Left(testMessage);
+      const testExceptionSupplier = () => new Error(testMessage);
+      const testFn = () => testLeft.orElseThrow(testExceptionSupplier);
+      const expectedResult = testMessage;
 
-      it("should throw the supplied error", () => {
-        const testExceptionSupplier = () => new Error(testMessage);
-        const testFn = () => testLeft.orElseThrow(testExceptionSupplier);
-
-        expect(testFn).to.throw(testMessage);
-      });
+      it("should throw the supplied error", () => expect(testFn).to.throw(expectedResult));
     });
 
     describe("#toMaybe", () => {
@@ -608,12 +611,14 @@ describe("Either", () => {
     });
 
     describe("#orElseGet", () => {
-      it("should return the value supplied by the function passed", () => {
-        const testValueSupplier = () => false;
-        const expectedResult = testValue;
+      const testRight = new Right(testValue);
+      const testValueSupplier = () => !testValue;
+      const expectedResult = testValue;
+      let actualResult = null;
 
-        expect(Right.from(testValue).orElseGet(testValueSupplier)).to.equal(expectedResult);
-      });
+      before(() => actualResult = testRight.orElseGet(testValueSupplier));
+
+      it("should return the value of the instance", () => expect(actualResult).to.equal(expectedResult));
     });
 
     describe("#orElseThrow", () => {

--- a/test/MaybeSpec.js
+++ b/test/MaybeSpec.js
@@ -355,31 +355,36 @@ describe("Maybe", () => {
 
     describe("#orElse", () => {
       const testNothing = new Nothing();
+      const testOrElseValue = testValue;
+      const expectedResult = testValue;
       let actualResult = null;
 
-      before(() => actualResult = testNothing.orElse(testValue));
+      before(() => actualResult = testNothing.orElse(testOrElseValue));
 
-      it("should return the value passed to the orElse method", () => expect(actualResult).to.equal(testValue));
+      it("should return the value passed", () => expect(actualResult).to.equal(expectedResult));
     });
 
     describe("#orElseGet", () => {
-      it("should return the value supplied by the function passed", () => {
-        const testValueSupplier = () => true;
-        const expectedResult = testValue;
+      const testNothing = new Nothing();
+      const testValueSupplier = () => testValue;
+      const expectedResult = testValue;
+      let actualResult = null;
 
-        expect(Nothing.from().orElseGet(testValueSupplier)).to.equal(expectedResult);
-      });
+      before(() => actualResult = testNothing.orElseGet(testValueSupplier));
+
+      it("should return the value supplied by the function passed", () =>
+        expect(actualResult).to.equal(expectedResult)
+      );
     });
 
     describe("#orElseThrow", () => {
       const testNothing = new Nothing();
+      const testExceptionSupplier = () => new Error();
 
       it("should throw the supplied error", () => {
-        const testMessage = "Test message.";
-        const testExceptionSupplier = () => new Error(testMessage);
         const testFn = () => testNothing.orElseThrow(testExceptionSupplier);
 
-        expect(testFn).to.throw(testMessage);
+        expect(testFn).to.throw();
       });
     });
 
@@ -586,25 +591,29 @@ describe("Maybe", () => {
     describe("#orElse", () => {
       const testJust = new Just(testValue);
       const testOrElseValue = !testValue;
+      const expectedValue = testValue;
       let actualResult = null;
 
       before(() => actualResult = testJust.orElse(testOrElseValue));
 
-      it("should return the value", () => expect(actualResult).to.eql(testValue));
+      it("should return the value of the instance", () => expect(actualResult).to.eql(expectedValue));
     });
 
     describe("#orElseGet", () => {
-      it("should return the value supplied by the function passed", () => {
-        const testValueSupplier = () => false;
-        const expectedResult = testValue;
+      const testJust = new Just(testValue);
+      const testValueSupplier = () => !testValue;
+      const expectedResult = testValue;
+      let actualResult = null;
 
-        expect(Just.from(testValue).orElseGet(testValueSupplier)).to.equal(expectedResult);
-      });
+      before(() => actualResult = testJust.orElseGet(testValueSupplier));
+
+      it("should return the value of the instance", () => expect(actualResult).to.equal(expectedResult));
     });
 
     describe("#orElseThrow", () => {
       const testJust = new Just(testValue);
-      const testOrElseThrow = sinon.spy(testValue => new Error(testValue));
+      const testOrElseThrow = sinon.spy(() => new Error());
+      const expectedResult = testValue;
 
       it("should not throw the supplied error", () => {
         const testFn = () => testJust.orElseThrow(testOrElseThrow);
@@ -613,7 +622,7 @@ describe("Maybe", () => {
       });
 
       it("should not call the provided method", () => expect(testOrElseThrow).to.not.be.called);
-      it("should return the value", () => expect(testJust.orElseThrow()).to.eql(testValue));
+      it("should return the value of the instance", () => expect(testJust.orElseThrow()).to.eql(expectedResult));
     });
 
     describe("#toEither", () => {

--- a/test/ValidationSpec.js
+++ b/test/ValidationSpec.js
@@ -452,6 +452,17 @@ describe("Validation", () => {
       );
     });
 
+    describe("#ifFailure", () => {
+      const testFailure = new Failure(testMessage);
+      const testIfFailure = sinon.spy(() => true);
+      let actualResult = null;
+
+      before(() => actualResult = testFailure.ifFailure(testIfFailure));
+
+      it("should return the instance", () => expect(actualResult).to.equal(testFailure));
+      it("should call the provided ifFailure method", () => expect(testIfFailure).to.be.calledWith([testMessage]));
+    });
+
     describe("#ifSuccess", () => {
       const testFailure = new Failure(testMessage);
       const testIfSuccess = sinon.spy(() => true);
@@ -488,20 +499,33 @@ describe("Validation", () => {
 
     describe("#orElse", () => {
       const testFailure = new Failure(testMessage);
-      const testOrElse = sinon.spy(value => `${value} used`);
+      const testOrElseValue = testValue;
+      const expectedResult = testValue;
       let actualResult = null;
 
-      before(() => actualResult = testFailure.orElse(testOrElse));
+      before(() => actualResult = testFailure.orElse(testOrElseValue));
 
-      it("should return the instance", () => expect(actualResult).to.equal(testFailure));
-      it("should pass the values to the orElse method", () => expect(testOrElse).to.be.calledWith(testFailure.value));
+      it("should return the value passed", () => expect(actualResult).to.equal(expectedResult));
+    });
+
+    describe("#orElseGet", () => {
+      const testFailure = new Failure(testMessage);
+      const testValueSupplier = () => testValue;
+      const expectedResult = testValue;
+      let actualResult = null;
+
+      before(() => actualResult = testFailure.orElseGet(testValueSupplier));
+
+      it("should return the value supplied by the function passed", () =>
+        expect(actualResult).to.equal(expectedResult)
+      );
     });
 
     describe("#orElseThrow", () => {
       const testFailure = new Failure(testMessage);
+      const testExceptionSupplier = testMessage => new Error(testMessage);
 
       it("should throw the supplied error", () => {
-        const testExceptionSupplier = testMessage => new Error(testMessage);
         const testFn = () => testFailure.orElseThrow(testExceptionSupplier);
 
         expect(testFn).to.throw(testMessage);
@@ -704,6 +728,17 @@ describe("Validation", () => {
       );
     });
 
+    describe("#ifFailure", () => {
+      const testSuccess = new Success(testValue);
+      const testIfValue = sinon.spy(() => true);
+      let actualResult = null;
+
+      before(() => actualResult = testSuccess.ifFailure(testIfValue));
+
+      it("should return the instance", () => expect(actualResult).to.equal(testSuccess));
+      it("should not call the provided ifFailure method", () => expect(testIfValue).to.not.be.called);
+    });
+
     describe("#ifSuccess", () => {
       const testSuccess = new Success(testValue);
       const testIfSuccess = sinon.spy(() => true);
@@ -742,20 +777,31 @@ describe("Validation", () => {
 
     describe("#orElse", () => {
       const testSuccess = new Success(testValue);
-      const testOrElse = sinon.spy(value => `${value} used`);
+      const testOrElseValue = !testValue;
+      const expectedValue = testValue;
       let actualResult = null;
 
-      before(() => actualResult = testSuccess.orElse(testOrElse));
+      before(() => actualResult = testSuccess.orElse(testOrElseValue));
 
-      it("should return the instance", () => expect(actualResult).to.equal(testSuccess));
-      it("should not call the provided orElse method", () => expect(testOrElse).to.not.be.called);
+      it("should return the value of the instance", () => expect(actualResult).to.eql(expectedValue));
+    });
+
+    describe("#orElseGet", () => {
+      const testSuccess = new Success(testValue);
+      const testValueSupplier = () => !testValue;
+      const expectedResult = testValue;
+      let actualResult = null;
+
+      before(() => actualResult = testSuccess.orElseGet(testValueSupplier));
+
+      it("should return the value of the instance", () => expect(actualResult).to.equal(expectedResult));
     });
 
     describe("#orElseThrow", () => {
       const testSuccess = new Success(testValue);
+      const testExceptionSupplier = testValue => new Error(testValue);
 
       it("should not throw the supplied error", () => {
-        const testExceptionSupplier = testValue => new Error(testValue);
         const testFn = () => testSuccess.orElseThrow(testExceptionSupplier);
 
         expect(testFn).to.not.throw();


### PR DESCRIPTION
* data/Either
  * Added #ifLeft.
  * Minor documentation cleanup.
* data/Maybe
  * Added #ifNothing.
  * Minor documentation cleanup.
* data/Validation
  * Added #ifFailure.
  * Added #orElseGet.
  * Changed #orElse to behave the same as Maybe#orElse.
  * Minor documenation cleanup.
* Updated tests accordingly.

Resolves #14
SemVer:Major